### PR TITLE
Adapt code for Substrate API changes

### DIFF
--- a/dix/blocks.go
+++ b/dix/blocks.go
@@ -22,6 +22,9 @@ type BlockData struct {
 	OnFinalize     json.RawMessage `json:"onFinalize"`
 	Logs           json.RawMessage `json:"logs"`
 	Extrinsics     json.RawMessage `json:"extrinsics"`
+	// Elastic scaling fields (available when useRcBlock parameter is used)
+	RcBlockNumber  *string         `json:"rcBlockNumber,omitempty"`
+	RcBlockHash    *string         `json:"rcBlockHash,omitempty"`
 }
 
 func IsValidAddress(address string) bool {

--- a/dix/chainreader.go
+++ b/dix/chainreader.go
@@ -19,6 +19,10 @@ type ChainReader interface {
 	GetStats() *MetricsStats
 }
 
+// Sidecar implements the ChainReader interface using Substrate API Sidecar
+// Supports both regular blocks and elastic scaling enabled parachains
+// Note: Elastic scaling support (v20.9.0+) allows multiple blocks per block height
+// The database schema uses (hash, created_at) as primary key to handle this
 type Sidecar struct {
 	relay   string
 	chain   string
@@ -156,6 +160,8 @@ func (s *Sidecar) FetchBlockRange(ctx context.Context, blockIDs []int) ([]BlockD
 }
 
 // fetchBlock makes a call to the sidecar API to fetch a single block
+// Note: With elastic scaling, multiple blocks may exist at the same height
+// This function returns the canonical block. For multi-block queries, use useRcBlock parameter
 func (s *Sidecar) FetchBlock(ctx context.Context, id int) (BlockData, error) {
 	start := time.Now()
 	defer func(start time.Time) {

--- a/dix/database.go
+++ b/dix/database.go
@@ -225,8 +225,9 @@ CREATE TABLE IF NOT EXISTS %[1]s
   on_finalize     jsonb,
   logs            jsonb,
   extrinsics      jsonb,
-  CONSTRAINT      %[2]s_pk PRIMARY KEY (block_id, created_at)
+  CONSTRAINT      %[2]s_pk PRIMARY KEY (hash, created_at)
 ) PARTITION BY RANGE (created_at);
+CREATE INDEX IF NOT EXISTS %[2]s_block_id_idx ON %[1]s (block_id);
 ALTER TABLE IF EXISTS %[1]s OWNER to dotidx;
 REVOKE ALL ON TABLE %[1]s FROM PUBLIC;
 GRANT SELECT ON TABLE %[1]s TO PUBLIC;
@@ -468,9 +469,8 @@ func (s *SQLDatabase) Save(items []BlockData, relayChain, chain string) error {
 			"block_id, created_at, hash, parent_hash, state_root, extrinsics_root, "+
 			"author_id, finalized, on_initialize, on_finalize, logs, extrinsics"+
 			") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) "+
-			"ON CONFLICT (block_id, created_at) DO UPDATE SET "+
-			"created_at = EXCLUDED.created_at, "+
-			"hash = EXCLUDED.hash, "+
+			"ON CONFLICT (hash, created_at) DO UPDATE SET "+
+			"block_id = EXCLUDED.block_id, "+
 			"parent_hash = EXCLUDED.parent_hash, "+
 			"state_root = EXCLUDED.state_root, "+
 			"extrinsics_root = EXCLUDED.extrinsics_root, "+

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@polkadot/extension-dapp": "^0.62.3",
     "@polkadot/util": "^13.5.7",
     "@polkadot/util-crypto": "^13.5.7",
-    "@substrate/api-sidecar": "^20.10.2",
+    "@substrate/api-sidecar": "^20.11.0",
     "@types/plotly.js": "^3.0.8",
     "n": "^10.2.0",
     "plotly.js-dist-min": "^3.1.2",


### PR DESCRIPTION
Update codebase to support Substrate's elastic scaling feature where multiple blocks can exist at the same block height. This is a breaking change to the database schema but ensures compatibility with parachains that have elastic scaling enabled.

Changes:
- Upgrade @substrate/api-sidecar from v20.10.2 to v20.11.0
- Add rcBlockNumber and rcBlockHash fields to BlockData struct for elastic scaling metadata
- Change database PRIMARY KEY from (block_id, created_at) to (hash, created_at) to support multiple blocks per height
- Add index on block_id for efficient querying
- Update database Save() to use new primary key constraint
- Update frontend API queries to handle multiple blocks per block_id:
  - getBlock() now orders by finalized DESC, created_at DESC and limits to 1 to return the canonical block
  - getBlocksByAddressForChain() explicitly lists columns and orders by hash for consistency
- Add documentation comments about elastic scaling support

Database migration notes:
- Existing databases will need schema migration to change primary key
- The new schema is backward compatible with non-elastic-scaling chains
- For elastic scaling chains, queries by block_id will prefer finalized blocks and use timestamp as tiebreaker