### PR TITLE
Read configuration parameters on startup

### DIFF
--- a/conf/conf-docker-dev.toml
+++ b/conf/conf-docker-dev.toml
@@ -84,3 +84,8 @@ zfs = true
 user = "prometheus"
 prometheus_ip = "127.0.0.1"
 prometheus_port = 9100
+
+[temporal]
+hostport = "localhost:7233"
+namespace = "dotidx"
+taskqueue = "dotidx-watcher"

--- a/conf/conf-horn.toml
+++ b/conf/conf-horn.toml
@@ -199,3 +199,8 @@ zfs = true
 user = "prometheus"
 prometheus_ip = "192.168.1.32"
 prometheus_port = 9100
+
+[temporal]
+hostport = "192.168.1.32:7233"
+namespace = "dotidx"
+taskqueue = "dotidx-watcher"

--- a/conf/conf-simple.toml
+++ b/conf/conf-simple.toml
@@ -95,3 +95,8 @@ zfs = true
 user = "prometheus"
 prometheus_ip = "127.0.0.1"
 prometheus_port = 9100
+
+[temporal]
+hostport = "localhost:7233"
+namespace = "dotidx"
+taskqueue = "dotidx-watcher"

--- a/conf/conf-spin.toml
+++ b/conf/conf-spin.toml
@@ -122,6 +122,7 @@ user = "prometheus"
 prometheus_ip = "192.168.1.32"
 prometheus_port = 9100
 
-[watch]
-temporal_ip = "192.168.1.32"
-temporal_port = 7233
+[temporal]
+hostport = "192.168.1.32:7233"
+namespace = "dotidx"
+taskqueue = "dotidx-watcher"

--- a/dix/mgrconfig.go
+++ b/dix/mgrconfig.go
@@ -35,6 +35,7 @@ type MgrConfig struct {
 	Filesystem            FilesystemConfig                      `toml:"filesystem"`
 	Monitoring            MonitoringConfig                      `toml:"monitoring"`
 	Watcher               OrchestratorConfig                    `toml:"watcher"`
+	Temporal              TemporalConfig                        `toml:"temporal"`
 }
 
 type DotidxDB struct {
@@ -106,6 +107,12 @@ type OrchestratorConfig struct {
 	MaxRestarts      int           `toml:"max_restarts"`
 	RestartBackoff   time.Duration `toml:"restart_backoff"`
 	OperationTimeout time.Duration `toml:"operation_timeout"`
+}
+
+type TemporalConfig struct {
+	HostPort  string `toml:"hostport"`  // Temporal server address (e.g., "localhost:7233")
+	Namespace string `toml:"namespace"` // Temporal namespace (e.g., "dotidx")
+	TaskQueue string `toml:"taskqueue"` // Task queue name (e.g., "dotidx-watcher")
 }
 
 func LoadMgrConfig(file string) (*MgrConfig, error) {


### PR DESCRIPTION
- Add TemporalConfig struct to dix/mgrconfig.go with hostport, namespace, and taskqueue fields
- Update MgrConfig to include Temporal configuration section
- Modify dixmgr main.go to read Temporal settings from config file with command-line flag fallback
- Add [temporal] section to all example configuration files (conf-simple.toml, conf-docker-dev.toml, conf-horn.toml, conf-spin.toml)
- Replace deprecated [watch] section in conf-spin.toml with new [temporal] section

This allows dixmgr to read Temporal server IP, port, namespace, and task queue from the configuration file at startup, while still supporting command-line flag overrides.