### PR TITLE
Rewrite dixbatch and dixcron as temporal services

### DIFF
--- a/cmd/dixmgr/TEMPORAL_SERVICES.md
+++ b/cmd/dixmgr/TEMPORAL_SERVICES.md
@@ -1,0 +1,358 @@
+# Temporal Services for Batch and Cron Operations
+
+This document describes the Temporal-based implementations of batch block indexing and cron query execution, which replace the standalone `dixbatch` and `dixcron` binaries.
+
+## Overview
+
+The new Temporal services provide:
+
+1. **BatchWorkflow** - Replaces `dixbatch` for block indexing
+2. **CronWorkflow** - Replaces `dixcron` for periodic query execution
+
+### Benefits of Temporal Implementation
+
+- **Better Observability**: View workflow status, history, and metrics in Temporal Web UI
+- **Automatic Retries**: Built-in retry policies for transient failures
+- **State Management**: Workflow state persists across restarts
+- **Scalability**: Easy horizontal scaling by adding more workers
+- **Continue-As-New**: Handles very long-running batch operations without history limits
+- **Scheduling**: Native cron support eliminates custom ticker logic
+
+## BatchWorkflow
+
+### Purpose
+Fetches blocks from a Polkadot parachain via Sidecar API and stores them in PostgreSQL.
+
+### Configuration
+
+```go
+type BatchWorkflowConfig struct {
+    RelayChain   string        // e.g., "polkadot"
+    Chain        string        // e.g., "assethub"
+    StartRange   int           // Starting block number
+    EndRange     int           // Ending block (-1 = use chain head)
+    BatchSize    int           // Blocks per batch request
+    MaxWorkers   int           // Maximum parallel workers
+    FlushTimeout time.Duration // Database flush timeout
+    SidecarURL   string        // e.g., "http://localhost:8080"
+}
+```
+
+### Starting a Batch Workflow
+
+#### Using Temporal CLI
+
+```bash
+# Index blocks from 1 to current head
+temporal workflow start \
+  --task-queue dotidx-watcher \
+  --type BatchWorkflow \
+  --workflow-id wf.batch.polkadot.assethub \
+  --input '{
+    "RelayChain": "polkadot",
+    "Chain": "assethub",
+    "StartRange": 1,
+    "EndRange": -1,
+    "BatchSize": 100,
+    "MaxWorkers": 10,
+    "FlushTimeout": "30s",
+    "SidecarURL": "http://localhost:8080"
+  }'
+
+# Index specific block range
+temporal workflow start \
+  --task-queue dotidx-watcher \
+  --type BatchWorkflow \
+  --workflow-id wf.batch.polkadot.assethub.1M-2M \
+  --input '{
+    "RelayChain": "polkadot",
+    "Chain": "assethub",
+    "StartRange": 1000000,
+    "EndRange": 2000000,
+    "BatchSize": 100,
+    "MaxWorkers": 20,
+    "FlushTimeout": "30s",
+    "SidecarURL": "http://localhost:8080"
+  }'
+```
+
+#### Using Go Client
+
+```go
+package main
+
+import (
+    "context"
+    "time"
+
+    "go.temporal.io/sdk/client"
+)
+
+func startBatchIndexing() error {
+    c, err := client.Dial(client.Options{
+        HostPort:  "localhost:7233",
+        Namespace: "dotidx",
+    })
+    if err != nil {
+        return err
+    }
+    defer c.Close()
+
+    config := BatchWorkflowConfig{
+        RelayChain:   "polkadot",
+        Chain:        "assethub",
+        StartRange:   1,
+        EndRange:     -1, // Use current head
+        BatchSize:    100,
+        MaxWorkers:   10,
+        FlushTimeout: 30 * time.Second,
+        SidecarURL:   "http://localhost:8080",
+    }
+
+    workflowOptions := client.StartWorkflowOptions{
+        ID:        "wf.batch.polkadot.assethub",
+        TaskQueue: "dotidx-watcher",
+    }
+
+    we, err := c.ExecuteWorkflow(context.Background(), workflowOptions,
+        "BatchWorkflow", config)
+    if err != nil {
+        return err
+    }
+
+    log.Printf("Started batch workflow: %s", we.GetID())
+    return nil
+}
+```
+
+### Workflow Behavior
+
+1. **Get Chain Head**: If `EndRange` is -1, fetches current chain head
+2. **Process in Chunks**: Processes blocks in 100k chunks to avoid large ranges
+3. **Check Existing Blocks**: Queries database to skip already-indexed blocks
+4. **Group into Batches**: Groups consecutive missing blocks for efficient batch processing
+5. **Parallel Processing**: Processes batches concurrently up to `MaxWorkers`
+6. **Continue-As-New**: After 500k blocks, uses Continue-As-New to reset workflow history
+
+### Activities Used
+
+- `GetChainHeadActivity` - Get current blockchain head
+- `CheckExistingBlocksActivity` - Check which blocks exist in DB
+- `ProcessSingleBlockActivity` - Fetch and store single block
+- `ProcessBlockBatchActivity` - Fetch and store batch of blocks
+
+## CronWorkflow
+
+### Purpose
+Executes registered SQL queries periodically to compute statistics and aggregations.
+
+### Configuration
+
+```go
+type CronWorkflowConfig struct {
+    HourlyCronSchedule string   // e.g., "0 * * * *"
+    DailyCronSchedule  string   // e.g., "0 0 * * *"
+    RegisteredQueries  []string // e.g., ["total_blocks_in_month", "total_addresses_in_month"]
+}
+```
+
+### Starting a Cron Workflow
+
+#### Hourly Execution (Current Month Blocks)
+
+```bash
+temporal workflow start \
+  --task-queue dotidx-watcher \
+  --type CronWorkflow \
+  --workflow-id wf.cron.hourly \
+  --cron "0 * * * *" \
+  --input '{
+    "HourlyCronSchedule": "0 * * * *",
+    "DailyCronSchedule": "0 0 * * *",
+    "RegisteredQueries": ["total_blocks_in_month"]
+  }'
+```
+
+#### Daily Execution (All Historical Queries)
+
+```bash
+temporal workflow start \
+  --task-queue dotidx-watcher \
+  --type CronWorkflow \
+  --workflow-id wf.cron.daily \
+  --cron "0 0 * * *" \
+  --input '{
+    "HourlyCronSchedule": "0 * * * *",
+    "DailyCronSchedule": "0 0 * * *",
+    "RegisteredQueries": ["total_blocks_in_month", "total_addresses_in_month"]
+  }'
+```
+
+### Workflow Behavior
+
+#### Hourly Execution
+- Executes only `total_blocks_in_month` for **current month**
+- Updates block count continuously as new blocks are indexed
+
+#### Daily Execution
+- Executes **all registered queries** for **all past months** (2019 onwards)
+- Skips months that already have results
+- Processes all indexed chains automatically
+
+### Registered Queries
+
+#### 1. total_blocks_in_month
+Counts total blocks indexed in a given month.
+
+```sql
+SELECT COUNT(*) as total_blocks
+FROM chain.{{.Relaychain}}_{{.Chain}}_blocks
+WHERE created_at >= '{{.Year}}-{{.Month}}-01'
+  AND created_at < '{{.Year}}-{{.Month}}-01'::date + INTERVAL '1 month'
+```
+
+#### 2. total_addresses_in_month
+Counts unique addresses active in a given month.
+
+```sql
+WITH month_bounds AS (
+    SELECT
+        MIN(block_id) as min_block,
+        MAX(block_id) as max_block
+    FROM chain.{{.Relaychain}}_{{.Chain}}_blocks
+    WHERE created_at >= '{{.Year}}-{{.Month}}-01'
+      AND created_at < '{{.Year}}-{{.Month}}-01'::date + INTERVAL '1 month'
+)
+SELECT COUNT(DISTINCT address) as total_addresses
+FROM chain.{{.Relaychain}}_{{.Chain}}_address_to_blocks atb
+CROSS JOIN month_bounds mb
+WHERE atb.block_id >= mb.min_block
+  AND atb.block_id <= mb.max_block
+```
+
+### Activities Used
+
+- `GetDatabaseInfoActivity` - Get all indexed chains
+- `CheckQueryResultExistsActivity` - Check if query result exists
+- `ExecuteAndStoreNamedQueryActivity` - Execute and store query result
+- `RegisterDefaultQueriesActivity` - Register default queries
+
+## Database Integration
+
+The Temporal services require a database connection to be set in the Activities:
+
+```go
+// In main.go, after creating activities:
+if config.Database != nil {
+    dbAdapter := NewDixDatabaseAdapter(database)
+    activities.SetDatabase(dbAdapter)
+
+    // Register default queries
+    ctx := context.Background()
+    activities.RegisterDefaultQueriesActivity(ctx)
+}
+```
+
+## Monitoring and Observability
+
+### Temporal Web UI
+View workflow status at: http://localhost:8080 (default Temporal UI)
+
+### Metrics
+All activities record metrics via Prometheus:
+- Activity execution count (success/error)
+- Activity duration
+- Block processing rate (for batch workflows)
+
+### Example Queries
+
+```promql
+# Batch processing rate
+rate(dixmgr_activity_duration_seconds_sum{activity="ProcessBlockBatch"}[5m])
+
+# Query execution errors
+dixmgr_activity_execution_total{activity="ExecuteAndStoreNamedQuery", status="error"}
+
+# Average activity duration
+dixmgr_activity_duration_seconds_sum / dixmgr_activity_duration_seconds_count
+```
+
+## Migration from dixbatch/dixcron
+
+### Before (Old Approach)
+
+```bash
+# Run batch manually
+./dixbatch -conf conf.toml -relayChain polkadot -chain assethub
+
+# Start cron service
+systemctl start dixcron.service
+```
+
+### After (Temporal Approach)
+
+```bash
+# Start batch workflow
+temporal workflow start \
+  --task-queue dotidx-watcher \
+  --type BatchWorkflow \
+  --workflow-id wf.batch.polkadot.assethub \
+  --input '{"RelayChain":"polkadot","Chain":"assethub",...}'
+
+# Start cron workflows (hourly + daily)
+temporal workflow start --type CronWorkflow --cron "0 * * * *" ...
+temporal workflow start --type CronWorkflow --cron "0 0 * * *" ...
+```
+
+## Advantages Over Old Implementation
+
+| Feature | dixbatch/dixcron | Temporal Services |
+|---------|------------------|-------------------|
+| **Observability** | Logs only | Temporal UI + Metrics |
+| **Retries** | Manual | Automatic with backoff |
+| **State** | Lost on crash | Persisted in Temporal |
+| **Scheduling** | systemd/cron | Temporal cron |
+| **Scalability** | Single process | Horizontal scaling |
+| **Progress Tracking** | None | Workflow history |
+| **Dependency Management** | Manual | Signal-based |
+| **Long-running Jobs** | Memory issues | Continue-As-New |
+
+## Performance Considerations
+
+### Batch Workflow
+- **MaxWorkers**: Balance between throughput and system load (recommended: 10-20)
+- **BatchSize**: Larger batches are more efficient but may timeout (recommended: 50-100)
+- **Continue-As-New**: Prevents workflow history from growing too large
+
+### Cron Workflow
+- **Hourly Schedule**: Lightweight, only updates current month
+- **Daily Schedule**: Heavier, processes all historical data
+- **Query Optimization**: Use indexed columns for date filtering
+
+## Troubleshooting
+
+### Batch Workflow Not Processing Blocks
+1. Check Sidecar URL is accessible: `curl http://localhost:8080/blocks/head`
+2. Verify database connection in activities
+3. Check worker is running: `temporal workflow list`
+4. View workflow history: `temporal workflow show --workflow-id wf.batch.polkadot.assethub`
+
+### Cron Workflow Not Executing
+1. Verify cron schedule syntax: https://crontab.guru/
+2. Check if queries are registered: look for "Registered default queries" in logs
+3. Ensure database info table has data: `SELECT * FROM chain.dotidx_database_info`
+
+### Activity Failures
+1. Check activity retry policy in workflow code
+2. View activity errors in Temporal UI
+3. Check metrics for error counts
+4. Review worker logs for detailed error messages
+
+## Future Enhancements
+
+- [ ] Dynamic worker scaling based on workload
+- [ ] Priority queues for urgent batch jobs
+- [ ] Query result caching
+- [ ] Batch workflow pause/resume
+- [ ] Custom query registration via API
+- [ ] Multi-region deployment support

--- a/cmd/dixmgr/activities.go
+++ b/cmd/dixmgr/activities.go
@@ -20,6 +20,7 @@ type Activities struct {
 	circuitBreakers *CircuitBreakerManager
 	healthHistory   *HealthHistoryStore
 	dynamicConfig   *DynamicConfig
+	database        Database // Database interface for batch and cron operations
 }
 
 func NewActivities(executeMode bool, metrics *MetricsCollector, alertManager *AlertManager, enableResourceMonitoring bool, cbManager *CircuitBreakerManager, healthHistory *HealthHistoryStore, dynamicConfig *DynamicConfig, processManager ProcessManager) (*Activities, error) {
@@ -65,4 +66,12 @@ func (a *Activities) Close() {
 	if a.healthHistory != nil {
 		a.healthHistory.Close()
 	}
+	if a.database != nil {
+		a.database.Close()
+	}
+}
+
+// SetDatabase sets the database for batch and cron operations
+func (a *Activities) SetDatabase(db Database) {
+	a.database = db
 }

--- a/cmd/dixmgr/activities_batch.go
+++ b/cmd/dixmgr/activities_batch.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/pierreaubert/dotidx/dix"
+)
+
+// GetChainHeadActivity fetches the current chain head block number
+func (a *Activities) GetChainHeadActivity(ctx context.Context, sidecarURL string) (int, error) {
+	start := time.Now()
+	log.Printf("[Activity] Getting chain head from: %s", sidecarURL)
+
+	// Create a temporary sidecar client
+	// Note: In production, we should cache these clients
+	sidecar := dix.NewSidecar("", "", sidecarURL)
+
+	headBlock, err := sidecar.GetChainHeadID()
+	if err != nil {
+		if a.metrics != nil {
+			a.metrics.RecordActivityExecution("GetChainHead", "error")
+		}
+		return 0, fmt.Errorf("failed to get chain head: %w", err)
+	}
+
+	if a.metrics != nil {
+		a.metrics.RecordActivityExecution("GetChainHead", "success")
+		a.metrics.RecordActivityDuration("GetChainHead", time.Since(start))
+	}
+
+	log.Printf("[Activity] Chain head: %d", headBlock)
+	return headBlock, nil
+}
+
+// CheckExistingBlocksActivity checks which blocks already exist in the database
+func (a *Activities) CheckExistingBlocksActivity(ctx context.Context,
+	relayChain, chain string, startRange, endRange int) (map[int]bool, error) {
+
+	start := time.Now()
+	log.Printf("[Activity] Checking existing blocks for %s/%s from %d to %d",
+		relayChain, chain, startRange, endRange)
+
+	// Get database instance from config
+	// Note: We need to add a database field to Activities
+	if a.database == nil {
+		return nil, fmt.Errorf("database not configured in activities")
+	}
+
+	existingBlocks, err := a.database.GetExistingBlocks(relayChain, chain, startRange, endRange)
+	if err != nil {
+		if a.metrics != nil {
+			a.metrics.RecordActivityExecution("CheckExistingBlocks", "error")
+		}
+		return nil, fmt.Errorf("failed to check existing blocks: %w", err)
+	}
+
+	existingCount := 0
+	for _, exists := range existingBlocks {
+		if exists {
+			existingCount++
+		}
+	}
+
+	if a.metrics != nil {
+		a.metrics.RecordActivityExecution("CheckExistingBlocks", "success")
+		a.metrics.RecordActivityDuration("CheckExistingBlocks", time.Since(start))
+	}
+
+	log.Printf("[Activity] Found %d existing blocks out of %d total",
+		existingCount, endRange-startRange+1)
+
+	return existingBlocks, nil
+}
+
+// ProcessSingleBlockActivity fetches and stores a single block
+func (a *Activities) ProcessSingleBlockActivity(ctx context.Context,
+	relayChain, chain string, blockID int, sidecarURL string) error {
+
+	start := time.Now()
+	log.Printf("[Activity] Processing single block %d for %s/%s", blockID, relayChain, chain)
+
+	// Create sidecar client
+	sidecar := dix.NewSidecar(relayChain, chain, sidecarURL)
+
+	// Fetch block
+	block, err := sidecar.FetchBlock(ctx, blockID)
+	if err != nil {
+		if a.metrics != nil {
+			a.metrics.RecordActivityExecution("ProcessSingleBlock", "error")
+		}
+		return fmt.Errorf("failed to fetch block %d: %w", blockID, err)
+	}
+
+	// Store block in database
+	if a.database == nil {
+		return fmt.Errorf("database not configured in activities")
+	}
+
+	err = a.database.Save([]dix.BlockData{block}, relayChain, chain)
+	if err != nil {
+		if a.metrics != nil {
+			a.metrics.RecordActivityExecution("ProcessSingleBlock", "error")
+		}
+		return fmt.Errorf("failed to save block %d: %w", blockID, err)
+	}
+
+	if a.metrics != nil {
+		a.metrics.RecordActivityExecution("ProcessSingleBlock", "success")
+		a.metrics.RecordActivityDuration("ProcessSingleBlock", time.Since(start))
+	}
+
+	log.Printf("[Activity] Successfully processed block %d", blockID)
+	return nil
+}
+
+// ProcessBlockBatchActivity fetches and stores a batch of blocks
+func (a *Activities) ProcessBlockBatchActivity(ctx context.Context,
+	relayChain, chain string, blockIDs []int, sidecarURL string) error {
+
+	start := time.Now()
+	log.Printf("[Activity] Processing block batch for %s/%s: %d blocks (range: %d-%d)",
+		relayChain, chain, len(blockIDs), blockIDs[0], blockIDs[len(blockIDs)-1])
+
+	if len(blockIDs) == 0 {
+		return fmt.Errorf("empty block batch")
+	}
+
+	// Create sidecar client
+	sidecar := dix.NewSidecar(relayChain, chain, sidecarURL)
+
+	// Fetch batch of blocks
+	blocks, err := sidecar.FetchBlockRange(ctx, blockIDs)
+	if err != nil {
+		if a.metrics != nil {
+			a.metrics.RecordActivityExecution("ProcessBlockBatch", "error")
+		}
+		return fmt.Errorf("failed to fetch block batch: %w", err)
+	}
+
+	if len(blocks) != len(blockIDs) {
+		log.Printf("[Activity] Warning: requested %d blocks but got %d", len(blockIDs), len(blocks))
+	}
+
+	// Store blocks in database
+	if a.database == nil {
+		return fmt.Errorf("database not configured in activities")
+	}
+
+	err = a.database.Save(blocks, relayChain, chain)
+	if err != nil {
+		if a.metrics != nil {
+			a.metrics.RecordActivityExecution("ProcessBlockBatch", "error")
+		}
+		return fmt.Errorf("failed to save block batch: %w", err)
+	}
+
+	if a.metrics != nil {
+		a.metrics.RecordActivityExecution("ProcessBlockBatch", "success")
+		a.metrics.RecordActivityDuration("ProcessBlockBatch", time.Since(start))
+	}
+
+	blocksPerSec := float64(len(blocks)) / time.Since(start).Seconds()
+	log.Printf("[Activity] Successfully processed %d blocks (%.2f blocks/sec)",
+		len(blocks), blocksPerSec)
+
+	return nil
+}

--- a/cmd/dixmgr/activities_cron.go
+++ b/cmd/dixmgr/activities_cron.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/pierreaubert/dotidx/dix"
+)
+
+// GetDatabaseInfoActivity retrieves information about all indexed chains
+func (a *Activities) GetDatabaseInfoActivity(ctx context.Context) ([]ChainInfo, error) {
+	start := time.Now()
+	log.Printf("[Activity] Getting database info")
+
+	if a.database == nil {
+		return nil, fmt.Errorf("database not configured in activities")
+	}
+
+	dbInfos, err := a.database.GetDatabaseInfo()
+	if err != nil {
+		if a.metrics != nil {
+			a.metrics.RecordActivityExecution("GetDatabaseInfo", "error")
+		}
+		return nil, fmt.Errorf("failed to get database info: %w", err)
+	}
+
+	// Convert to ChainInfo format
+	chains := make([]ChainInfo, len(dbInfos))
+	for i, info := range dbInfos {
+		chains[i] = ChainInfo{
+			RelayChain: info.Relaychain,
+			Chain:      info.Chain,
+		}
+	}
+
+	if a.metrics != nil {
+		a.metrics.RecordActivityExecution("GetDatabaseInfo", "success")
+		a.metrics.RecordActivityDuration("GetDatabaseInfo", time.Since(start))
+	}
+
+	log.Printf("[Activity] Found %d indexed chains", len(chains))
+	return chains, nil
+}
+
+// CheckQueryResultExistsActivity checks if a query result already exists
+func (a *Activities) CheckQueryResultExistsActivity(ctx context.Context,
+	relayChain, chain, queryName string, year, month int) (bool, error) {
+
+	start := time.Now()
+	log.Printf("[Activity] Checking if query result exists: %s/%s, query=%s, year=%d, month=%d",
+		relayChain, chain, queryName, year, month)
+
+	if a.database == nil {
+		return false, fmt.Errorf("database not configured in activities")
+	}
+
+	// Try to read the query result timestamp
+	// If it exists, the timestamp will be non-zero
+	timestamp, err := a.database.ReadTimeNamedQuery(ctx, relayChain, chain, queryName, year, month)
+	if err != nil {
+		// Error means the result doesn't exist or there was a database error
+		// We'll treat this as "doesn't exist" to allow retry
+		log.Printf("[Activity] Query result not found or error: %v", err)
+		if a.metrics != nil {
+			a.metrics.RecordActivityExecution("CheckQueryResultExists", "success")
+			a.metrics.RecordActivityDuration("CheckQueryResultExists", time.Since(start))
+		}
+		return false, nil
+	}
+
+	// Check if timestamp is non-zero (result exists)
+	exists := !timestamp.IsZero()
+
+	if a.metrics != nil {
+		a.metrics.RecordActivityExecution("CheckQueryResultExists", "success")
+		a.metrics.RecordActivityDuration("CheckQueryResultExists", time.Since(start))
+	}
+
+	log.Printf("[Activity] Query result exists: %v (timestamp: %v)", exists, timestamp)
+	return exists, nil
+}
+
+// ExecuteAndStoreNamedQueryActivity executes a registered query and stores the result
+func (a *Activities) ExecuteAndStoreNamedQueryActivity(ctx context.Context,
+	relayChain, chain, queryName string, year, month int) error {
+
+	start := time.Now()
+	log.Printf("[Activity] Executing and storing query: %s/%s, query=%s, year=%d, month=%d",
+		relayChain, chain, queryName, year, month)
+
+	if a.database == nil {
+		return fmt.Errorf("database not configured in activities")
+	}
+
+	// Execute and store the query
+	err := a.database.ExecuteAndStoreNamedQuery(ctx, relayChain, chain, queryName, year, month)
+	if err != nil {
+		if a.metrics != nil {
+			a.metrics.RecordActivityExecution("ExecuteAndStoreNamedQuery", "error")
+		}
+		return fmt.Errorf("failed to execute and store query: %w", err)
+	}
+
+	if a.metrics != nil {
+		a.metrics.RecordActivityExecution("ExecuteAndStoreNamedQuery", "success")
+		a.metrics.RecordActivityDuration("ExecuteAndStoreNamedQuery", time.Since(start))
+	}
+
+	log.Printf("[Activity] Successfully executed and stored query (duration: %v)", time.Since(start))
+	return nil
+}
+
+// RegisterDefaultQueriesActivity registers the default queries used by dixcron
+func (a *Activities) RegisterDefaultQueriesActivity(ctx context.Context) error {
+	start := time.Now()
+	log.Printf("[Activity] Registering default queries")
+
+	// Query 1: Total blocks in month
+	totalBlocksQuery := `
+		SELECT COUNT(*) as total_blocks
+		FROM chain.{{.Relaychain}}_{{.Chain}}_blocks
+		WHERE created_at >= '{{.Year}}-{{.Month}}-01'
+		  AND created_at < '{{.Year}}-{{.Month}}-01'::date + INTERVAL '1 month'
+	`
+
+	err := dix.RegisterQuery("total_blocks_in_month", totalBlocksQuery,
+		"Count total blocks indexed in a given month")
+	if err != nil && err.Error() != "query with name 'total_blocks_in_month' already registered" {
+		log.Printf("[Activity] Warning: failed to register total_blocks_in_month: %v", err)
+	}
+
+	// Query 2: Total addresses in month
+	totalAddressesQuery := `
+		WITH month_bounds AS (
+			SELECT
+				MIN(block_id) as min_block,
+				MAX(block_id) as max_block
+			FROM chain.{{.Relaychain}}_{{.Chain}}_blocks
+			WHERE created_at >= '{{.Year}}-{{.Month}}-01'
+			  AND created_at < '{{.Year}}-{{.Month}}-01'::date + INTERVAL '1 month'
+		)
+		SELECT COUNT(DISTINCT address) as total_addresses
+		FROM chain.{{.Relaychain}}_{{.Chain}}_address_to_blocks atb
+		CROSS JOIN month_bounds mb
+		WHERE atb.block_id >= mb.min_block
+		  AND atb.block_id <= mb.max_block
+	`
+
+	err = dix.RegisterQuery("total_addresses_in_month", totalAddressesQuery,
+		"Count unique addresses active in a given month")
+	if err != nil && err.Error() != "query with name 'total_addresses_in_month' already registered" {
+		log.Printf("[Activity] Warning: failed to register total_addresses_in_month: %v", err)
+	}
+
+	if a.metrics != nil {
+		a.metrics.RecordActivityExecution("RegisterDefaultQueries", "success")
+		a.metrics.RecordActivityDuration("RegisterDefaultQueries", time.Since(start))
+	}
+
+	log.Printf("[Activity] Default queries registered")
+	return nil
+}

--- a/cmd/dixmgr/config.go
+++ b/cmd/dixmgr/config.go
@@ -104,6 +104,25 @@ type AlertConfig struct {
 	DisabledRules  []string             // List of disabled rule names
 }
 
+// BatchWorkflowConfig represents configuration for batch block indexing
+type BatchWorkflowConfig struct {
+	RelayChain   string        // Relay chain name (e.g., "polkadot")
+	Chain        string        // Chain name (e.g., "assethub")
+	StartRange   int           // Starting block number
+	EndRange     int           // Ending block number (-1 = use chain head)
+	BatchSize    int           // Blocks per batch request
+	MaxWorkers   int           // Maximum parallel workers
+	FlushTimeout time.Duration // Database flush timeout
+	SidecarURL   string        // Sidecar API URL (e.g., "http://localhost:8080")
+}
+
+// CronWorkflowConfig represents configuration for periodic query execution
+type CronWorkflowConfig struct {
+	HourlyCronSchedule string // Cron schedule for hourly queries (e.g., "0 * * * *")
+	DailyCronSchedule  string // Cron schedule for daily queries (e.g., "0 0 * * *")
+	RegisteredQueries  []string // List of registered query names to execute
+}
+
 // WatcherConfig represents the complete watcher configuration
 type WatcherConfig struct {
 	Metrics MetricsConfig // Metrics configuration

--- a/cmd/dixmgr/database.go
+++ b/cmd/dixmgr/database.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/pierreaubert/dotidx/dix"
+)
+
+// Database is an interface wrapper around dix.Database
+// This allows us to use the database in activities
+type Database interface {
+	GetExistingBlocks(relayChain, chain string, startRange, endRange int) (map[int]bool, error)
+	Save(items []dix.BlockData, relayChain, chain string) error
+	GetDatabaseInfo() ([]dix.DatabaseInfo, error)
+	ReadTimeNamedQuery(ctx context.Context, relayChain, chain, queryName string, year, month int) (time.Time, error)
+	ExecuteAndStoreNamedQuery(ctx context.Context, relayChain, chain, queryName string, year, month int) error
+	Close() error
+}
+
+// DixDatabaseAdapter adapts dix.Database to our Database interface
+type DixDatabaseAdapter struct {
+	db dix.Database
+}
+
+// NewDixDatabaseAdapter creates a new adapter
+func NewDixDatabaseAdapter(db dix.Database) Database {
+	return &DixDatabaseAdapter{db: db}
+}
+
+func (d *DixDatabaseAdapter) GetExistingBlocks(relayChain, chain string, startRange, endRange int) (map[int]bool, error) {
+	return d.db.GetExistingBlocks(relayChain, chain, startRange, endRange)
+}
+
+func (d *DixDatabaseAdapter) Save(items []dix.BlockData, relayChain, chain string) error {
+	return d.db.Save(items, relayChain, chain)
+}
+
+func (d *DixDatabaseAdapter) GetDatabaseInfo() ([]dix.DatabaseInfo, error) {
+	return d.db.GetDatabaseInfo()
+}
+
+func (d *DixDatabaseAdapter) ReadTimeNamedQuery(ctx context.Context, relayChain, chain, queryName string, year, month int) (time.Time, error) {
+	return d.db.ReadTimeNamedQuery(ctx, relayChain, chain, queryName, year, month)
+}
+
+func (d *DixDatabaseAdapter) ExecuteAndStoreNamedQuery(ctx context.Context, relayChain, chain, queryName string, year, month int) error {
+	return d.db.ExecuteAndStoreNamedQuery(ctx, relayChain, chain, queryName, year, month)
+}
+
+func (d *DixDatabaseAdapter) Close() error {
+	return d.db.Close()
+}

--- a/cmd/dixmgr/helpers.go
+++ b/cmd/dixmgr/helpers.go
@@ -44,6 +44,14 @@ func WorkflowIDSvc(name string) string {
 	return fmt.Sprintf("wf.svc.%s", name)
 }
 
+func WorkflowIDBatch(relay, chain string) string {
+	return fmt.Sprintf("wf.batch.%s.%s", relay, chain)
+}
+
+func WorkflowIDCron(schedule string) string {
+	return fmt.Sprintf("wf.cron.%s", schedule)
+}
+
 // FromMgrConfigToInfraInput converts MgrConfig to InfrastructureWorkflowInput
 // It validates port conventions and derives service names, RPC ports, and signals
 func FromMgrConfigToInfraInput(cfg *dix.MgrConfig, watchInterval, maxRestarts int, restartBackoff int) (InfrastructureWorkflowInput, error) {

--- a/cmd/dixmgr/main.go
+++ b/cmd/dixmgr/main.go
@@ -237,6 +237,8 @@ func main() {
 	w.RegisterWorkflow(ClusterWorkflowExample)
 	w.RegisterWorkflow(InfrastructureWorkflow)
 	w.RegisterWorkflow(DependentServiceWorkflow)
+	w.RegisterWorkflow(BatchWorkflow)
+	w.RegisterWorkflow(CronWorkflow)
 
 	// Register activities
 	w.RegisterActivity(activities.CheckSystemdServiceActivity)
@@ -256,6 +258,18 @@ func main() {
 	w.RegisterActivity(activities.GetProcessOutputActivity)
 	w.RegisterActivity(activities.KillProcessActivity)
 	w.RegisterActivity(activities.ListProcessesActivity)
+
+	// Register batch processing activities
+	w.RegisterActivity(activities.GetChainHeadActivity)
+	w.RegisterActivity(activities.CheckExistingBlocksActivity)
+	w.RegisterActivity(activities.ProcessSingleBlockActivity)
+	w.RegisterActivity(activities.ProcessBlockBatchActivity)
+
+	// Register cron query activities
+	w.RegisterActivity(activities.GetDatabaseInfoActivity)
+	w.RegisterActivity(activities.CheckQueryResultExistsActivity)
+	w.RegisterActivity(activities.ExecuteAndStoreNamedQueryActivity)
+	w.RegisterActivity(activities.RegisterDefaultQueriesActivity)
 
 	log.Printf("Registered workflows and activities on task queue: %s", actualTaskQueue)
 

--- a/cmd/dixmgr/workflow_batch.go
+++ b/cmd/dixmgr/workflow_batch.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+// BatchWorkflow orchestrates batch block indexing for a specific chain
+// This workflow replaces the dixbatch binary functionality using Temporal
+func BatchWorkflow(ctx workflow.Context, config BatchWorkflowConfig) error {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("BatchWorkflow started",
+		"relayChain", config.RelayChain,
+		"chain", config.Chain,
+		"startRange", config.StartRange,
+		"endRange", config.EndRange)
+
+	// Configure activity options with retries
+	activityOptions := workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Minute, // Long timeout for batch operations
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    time.Minute,
+			MaximumAttempts:    5,
+		},
+	}
+	ctx = workflow.WithActivityOptions(ctx, activityOptions)
+
+	// Step 1: Get current chain head if EndRange is -1
+	endRange := config.EndRange
+	if endRange == -1 {
+		var headBlock int
+		err := workflow.ExecuteActivity(ctx, "GetChainHeadActivity",
+			config.SidecarURL).Get(ctx, &headBlock)
+		if err != nil {
+			logger.Error("Failed to get chain head", "error", err)
+			return fmt.Errorf("failed to get chain head: %w", err)
+		}
+		endRange = headBlock
+		logger.Info("Using chain head as end range", "headBlock", headBlock)
+	}
+
+	// Step 2: Process blocks in chunks (100k at a time to avoid huge ranges)
+	stepRange := 100000
+	totalBlocks := endRange - config.StartRange + 1
+	logger.Info("Starting batch processing",
+		"totalBlocks", totalBlocks,
+		"stepRange", stepRange)
+
+	currentStart := config.StartRange
+	processedBlocks := 0
+
+	for currentStart <= endRange {
+		currentEnd := currentStart + stepRange - 1
+		if currentEnd > endRange {
+			currentEnd = endRange
+		}
+
+		logger.Info("Processing range",
+			"start", currentStart,
+			"end", currentEnd,
+			"blocks", currentEnd-currentStart+1)
+
+		// Step 3: Check which blocks already exist in this range
+		var existingBlocks map[int]bool
+		err := workflow.ExecuteActivity(ctx, "CheckExistingBlocksActivity",
+			config.RelayChain, config.Chain, currentStart, currentEnd).Get(ctx, &existingBlocks)
+		if err != nil {
+			logger.Error("Failed to check existing blocks", "error", err)
+			return fmt.Errorf("failed to check existing blocks: %w", err)
+		}
+
+		// Step 4: Identify missing blocks and group into batches
+		missingBlocks := []int{}
+		for blockID := currentStart; blockID <= currentEnd; blockID++ {
+			if !existingBlocks[blockID] {
+				missingBlocks = append(missingBlocks, blockID)
+			}
+		}
+
+		logger.Info("Found missing blocks",
+			"count", len(missingBlocks),
+			"total", currentEnd-currentStart+1)
+
+		if len(missingBlocks) == 0 {
+			logger.Info("No missing blocks in this range, skipping")
+			currentStart = currentEnd + 1
+			continue
+		}
+
+		// Step 5: Process missing blocks in parallel batches
+		// Group consecutive blocks into continuous batches
+		batches := groupIntoContinuousBatches(missingBlocks, config.BatchSize)
+
+		logger.Info("Processing batches",
+			"batchCount", len(batches),
+			"maxWorkers", config.MaxWorkers)
+
+		// Process batches with concurrency control
+		err = processBatchesConcurrently(ctx, config, batches, logger)
+		if err != nil {
+			logger.Error("Failed to process batches", "error", err)
+			return fmt.Errorf("failed to process batches: %w", err)
+		}
+
+		processedBlocks += len(missingBlocks)
+		logger.Info("Range processing complete",
+			"processedInRange", len(missingBlocks),
+			"totalProcessed", processedBlocks)
+
+		// Move to next range
+		currentStart = currentEnd + 1
+
+		// Check if we need to use Continue-As-New to avoid history size limits
+		// Temporal workflows should use Continue-As-New after processing significant work
+		if processedBlocks > 500000 && currentStart <= endRange {
+			logger.Info("Using Continue-As-New to reset workflow history",
+				"processedSoFar", processedBlocks,
+				"remaining", endRange-currentStart+1)
+
+			// Create new config with updated start range
+			newConfig := config
+			newConfig.StartRange = currentStart
+
+			return workflow.NewContinueAsNewError(ctx, BatchWorkflow, newConfig)
+		}
+	}
+
+	logger.Info("BatchWorkflow completed successfully",
+		"totalProcessed", processedBlocks)
+
+	return nil
+}
+
+// groupIntoContinuousBatches groups block IDs into continuous ranges
+func groupIntoContinuousBatches(blockIDs []int, batchSize int) [][]int {
+	if len(blockIDs) == 0 {
+		return [][]int{}
+	}
+
+	batches := [][]int{}
+	currentBatch := []int{blockIDs[0]}
+
+	for i := 1; i < len(blockIDs); i++ {
+		// If continuous and batch not full, add to current batch
+		if blockIDs[i] == blockIDs[i-1]+1 && len(currentBatch) < batchSize {
+			currentBatch = append(currentBatch, blockIDs[i])
+		} else {
+			// Start new batch
+			batches = append(batches, currentBatch)
+			currentBatch = []int{blockIDs[i]}
+		}
+	}
+
+	// Add last batch
+	if len(currentBatch) > 0 {
+		batches = append(batches, currentBatch)
+	}
+
+	return batches
+}
+
+// processBatchesConcurrently processes batches with controlled concurrency
+func processBatchesConcurrently(ctx workflow.Context, config BatchWorkflowConfig,
+	batches [][]int, logger workflow.Logger) error {
+
+	// Use Temporal's parallel execution
+	// Split work between batch and single block processing
+	futures := []workflow.Future{}
+	activeFutures := 0
+
+	for _, batch := range batches {
+		// Wait if we've reached max workers
+		for activeFutures >= config.MaxWorkers {
+			// Wait for any future to complete
+			workflow.Await(ctx, func() bool {
+				completed := 0
+				for _, f := range futures {
+					if f != nil {
+						select {
+						case <-f.GetChannel():
+							completed++
+						default:
+						}
+					}
+				}
+				return completed > 0
+			})
+			activeFutures--
+		}
+
+		// Process batch based on size
+		var future workflow.Future
+		if len(batch) > 1 {
+			// Use batch processing for continuous ranges
+			future = workflow.ExecuteActivity(ctx, "ProcessBlockBatchActivity",
+				config.RelayChain, config.Chain, batch, config.SidecarURL)
+		} else {
+			// Use single block processing for isolated blocks
+			future = workflow.ExecuteActivity(ctx, "ProcessSingleBlockActivity",
+				config.RelayChain, config.Chain, batch[0], config.SidecarURL)
+		}
+
+		futures = append(futures, future)
+		activeFutures++
+	}
+
+	// Wait for all remaining futures
+	for _, future := range futures {
+		if future != nil {
+			err := future.Get(ctx, nil)
+			if err != nil {
+				logger.Error("Batch processing failed", "error", err)
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/dixmgr/workflow_cron.go
+++ b/cmd/dixmgr/workflow_cron.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+// CronWorkflow executes registered queries on a schedule
+// This workflow replaces the dixcron binary functionality using Temporal's native cron support
+func CronWorkflow(ctx workflow.Context, config CronWorkflowConfig) error {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("CronWorkflow started", "queries", len(config.RegisteredQueries))
+
+	// Configure activity options with retries
+	activityOptions := workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Minute, // Long timeout for expensive queries
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    5 * time.Minute,
+			MaximumAttempts:    3,
+		},
+	}
+	ctx = workflow.WithActivityOptions(ctx, activityOptions)
+
+	// Determine if this is an hourly or daily execution
+	// This is determined by the cron schedule used to trigger the workflow
+	cronSchedule := workflow.GetInfo(ctx).CronSchedule
+	isHourly := cronSchedule != nil && *cronSchedule == config.HourlyCronSchedule
+
+	logger.Info("Determining execution type",
+		"cronSchedule", cronSchedule,
+		"isHourly", isHourly)
+
+	// Step 1: Get all indexed chains from database
+	var chains []ChainInfo
+	err := workflow.ExecuteActivity(ctx, "GetDatabaseInfoActivity").Get(ctx, &chains)
+	if err != nil {
+		logger.Error("Failed to get database info", "error", err)
+		return fmt.Errorf("failed to get database info: %w", err)
+	}
+
+	logger.Info("Found indexed chains", "count", len(chains))
+
+	// Step 2: Get current time for determining which months to process
+	currentTime := workflow.Now(ctx)
+	currentYear := currentTime.Year()
+	currentMonth := int(currentTime.Month())
+
+	if isHourly {
+		// Hourly execution: only compute current month's block count
+		err = executeCurrentMonthQueries(ctx, chains, currentYear, currentMonth, logger)
+	} else {
+		// Daily execution: compute all registered queries for all past months
+		err = executeHistoricalQueries(ctx, config, chains, currentYear, currentMonth, logger)
+	}
+
+	if err != nil {
+		logger.Error("Query execution failed", "error", err)
+		return err
+	}
+
+	logger.Info("CronWorkflow completed successfully")
+	return nil
+}
+
+// executeCurrentMonthQueries executes block count query for current month (hourly)
+func executeCurrentMonthQueries(ctx workflow.Context, chains []ChainInfo,
+	year, month int, logger workflow.Logger) error {
+
+	logger.Info("Executing current month queries", "year", year, "month", month)
+
+	for _, chain := range chains {
+		logger.Info("Processing chain for current month",
+			"relayChain", chain.RelayChain,
+			"chain", chain.Chain)
+
+		// Execute the total_blocks_in_month query for current month
+		err := workflow.ExecuteActivity(ctx, "ExecuteAndStoreNamedQueryActivity",
+			chain.RelayChain, chain.Chain, "total_blocks_in_month", year, month).Get(ctx, nil)
+
+		if err != nil {
+			logger.Error("Failed to execute current month query",
+				"relayChain", chain.RelayChain,
+				"chain", chain.Chain,
+				"error", err)
+			// Continue with other chains even if one fails
+			continue
+		}
+
+		logger.Info("Current month query completed",
+			"relayChain", chain.RelayChain,
+			"chain", chain.Chain)
+	}
+
+	return nil
+}
+
+// executeHistoricalQueries executes all registered queries for all past months (daily)
+func executeHistoricalQueries(ctx workflow.Context, config CronWorkflowConfig,
+	chains []ChainInfo, currentYear, currentMonth int, logger workflow.Logger) error {
+
+	logger.Info("Executing historical queries",
+		"queries", len(config.RegisteredQueries),
+		"chains", len(chains))
+
+	// Process from 2019 (first year) to current month
+	firstYear := 2019
+
+	for _, chain := range chains {
+		for _, queryName := range config.RegisteredQueries {
+			// Process each year/month combination
+			for year := firstYear; year <= currentYear; year++ {
+				startMonth := 1
+				endMonth := 12
+
+				// For current year, only process up to current month
+				if year == currentYear {
+					endMonth = currentMonth
+				}
+
+				for month := startMonth; month <= endMonth; month++ {
+					// Skip current/future months for registered queries
+					if year == currentYear && month >= currentMonth {
+						continue
+					}
+
+					logger.Info("Processing query",
+						"query", queryName,
+						"relayChain", chain.RelayChain,
+						"chain", chain.Chain,
+						"year", year,
+						"month", month)
+
+					// Check if result already exists
+					var exists bool
+					err := workflow.ExecuteActivity(ctx, "CheckQueryResultExistsActivity",
+						chain.RelayChain, chain.Chain, queryName, year, month).Get(ctx, &exists)
+
+					if err != nil {
+						logger.Error("Failed to check query result existence",
+							"error", err)
+						continue
+					}
+
+					if exists {
+						logger.Info("Query result already exists, skipping",
+							"query", queryName,
+							"year", year,
+							"month", month)
+						continue
+					}
+
+					// Execute and store the query
+					err = workflow.ExecuteActivity(ctx, "ExecuteAndStoreNamedQueryActivity",
+						chain.RelayChain, chain.Chain, queryName, year, month).Get(ctx, nil)
+
+					if err != nil {
+						logger.Error("Failed to execute query",
+							"query", queryName,
+							"relayChain", chain.RelayChain,
+							"chain", chain.Chain,
+							"year", year,
+							"month", month,
+							"error", err)
+						// Continue with other queries even if one fails
+						continue
+					}
+
+					logger.Info("Query executed successfully",
+						"query", queryName,
+						"relayChain", chain.RelayChain,
+						"chain", chain.Chain,
+						"year", year,
+						"month", month)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// ChainInfo represents information about an indexed chain
+type ChainInfo struct {
+	RelayChain string
+	Chain      string
+}


### PR DESCRIPTION
This commit replaces the standalone dixbatch and dixcron binaries with Temporal-based workflows that provide better observability, automatic retries, and state management.

Changes:
- Add BatchWorkflow for block indexing (replaces dixbatch)
  - Processes blocks in chunks with parallel workers
  - Automatic Continue-As-New for long-running jobs
  - Checks existing blocks to avoid re-processing

- Add CronWorkflow for periodic query execution (replaces dixcron)
  - Hourly schedule for current month block counts
  - Daily schedule for historical query processing
  - Automatic chain discovery from database

- Implement batch processing activities:
  - GetChainHeadActivity
  - CheckExistingBlocksActivity
  - ProcessSingleBlockActivity
  - ProcessBlockBatchActivity

- Implement cron query activities:
  - GetDatabaseInfoActivity
  - CheckQueryResultExistsActivity
  - ExecuteAndStoreNamedQueryActivity
  - RegisterDefaultQueriesActivity

- Add database adapter for activities
- Update configuration structures
- Add workflow ID helpers
- Include comprehensive documentation (TEMPORAL_SERVICES.md)

Benefits:
- Better observability via Temporal Web UI
- Automatic retries with exponential backoff
- Workflow state persists across restarts
- Easy horizontal scaling
- Native cron scheduling
- Progress tracking and history